### PR TITLE
Ensure the batch file is emptied on shutdown

### DIFF
--- a/elasticsearch/CMakeLists.txt
+++ b/elasticsearch/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0)
-project(elasticsearch VERSION 1.0.1 LANGUAGES C)
+project(elasticsearch VERSION 1.0.2 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Elasticsearch encoders and outputs")
 set(MODULE_DEPENDENCIES heka_copy_tests rjson ep_cjson ep_socket) # fail the build if all the required modules were not specified
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${PACKAGE_PREFIX}-heka (>= 1.0), ${PACKAGE_PREFIX}-rjson (>= 1.0), ${PACKAGE_PREFIX}-cjson (>= 2.1), ${PACKAGE_PREFIX}-socket (>= 3.0)")

--- a/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
+++ b/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
@@ -174,8 +174,9 @@ function timer_event(ns, shutdown)
             retry = false
             batch_count = 0
             batch:close()
-            if not shutdown then
-                batch = assert(io.open(batch_file, "w"))
+            batch = assert(io.open(batch_file, "w"))
+            if shutdown then
+                batch:close()
             end
         end
     end


### PR DESCRIPTION
When the sandbox is being shutdown and the `flush_on_shutdown` option is set, the batch file need to be emptied or its content will be sent twice to elastic search.