### PR TITLE
Parity with current infra decoding

### DIFF
--- a/moz_telemetry/CMakeLists.txt
+++ b/moz_telemetry/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0)
-project(moz-telemetry VERSION 1.1.2 LANGUAGES C)
+project(moz-telemetry VERSION 1.2.0 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Mozilla Firefox Telemetry Data Processing")
 set(MODULE_DEPENDENCIES ep_cjson rjson)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${PACKAGE_PREFIX}-elasticsearch (>= 1.0)")

--- a/moz_telemetry/modules/moz_telemetry/extract_dimensions.lua
+++ b/moz_telemetry/modules/moz_telemetry/extract_dimensions.lua
@@ -126,10 +126,30 @@ end
 local schemas = {}
 local function load_schemas()
     local schema_files = {
-        main    = string.format("%s/telemetry/main.schema.json", cfg.schema_path),
-        crash   = string.format("%s/telemetry/crash.schema.json", cfg.schema_path),
-        core    = string.format("%s/telemetry/core.schema.json", cfg.schema_path),
-        }
+        ["main"]                                 = string.format("%s/telemetry/main.schema.json", cfg.schema_path),
+        ["crash"]                                = string.format("%s/telemetry/crash.schema.json", cfg.schema_path),
+        ["core"]                                 = string.format("%s/telemetry/core.schema.json", cfg.schema_path),
+        -- apply vacuous schemas for all other known ping types
+        ["idle-daily"]                           = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["saved-session"]                        = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["android-anr-report"]                   = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["ftu"]                                  = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["loop"]                                 = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["flash-video"]                          = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["activation"]                           = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["deletion"]                             = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["uitour-tag"]                           = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["heartbeat"]                            = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["b2g-installer-device"]                 = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["b2g-installer-flash"]                  = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["advancedtelemetry"]                    = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["appusage"]                             = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["testpilot"]                            = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["testpilottest"]                        = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["malware-addon-states"]                 = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["sync"]                                 = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+        ["outofdate-notifications-system-addon"] = string.format("%s/telemetry/generic.schema.json", cfg.schema_path),
+    }
     for k,v in pairs(schema_files) do
         local fh = assert(io.input(v))
         local schema = fh:read("*a")


### PR DESCRIPTION
This takes a bunch of logic from https://github.com/mozilla-services/data-pipeline/blob/master/heka/sandbox/decoders/extract_telemetry_dimensions.lua to make sure the new infra output resembles the current output as closely as possible.

It also makes sure we don't throw away known ping types that don't have a schema. This can probably be improved to take as config a mapping of ping types to schemas so that it's not all hard-coded here.

@trink r?