### PR TITLE
Extract payload objects from saved-session pings

### DIFF
--- a/moz_telemetry/io_modules/decoders/moz_telemetry/ping.lua
+++ b/moz_telemetry/io_modules/decoders/moz_telemetry/ping.lua
@@ -172,6 +172,7 @@ local extract_payload_objects = {
         "gc",
         },
     }
+extract_payload_objects["saved-session"] = extract_payload_objects["main"]
 
 local environment_objects = {
     "addons",


### PR DESCRIPTION
Per https://github.com/mozilla-services/data-pipeline/blob/master/heka/sandbox/decoders/extract_telemetry_dimensions.lua#L206