### PR TITLE
add a heka message decoder config that doesn't clobber the message metadata

### DIFF
--- a/heka/io_modules/decoders/heka/json.lua
+++ b/heka/io_modules/decoders/heka/json.lua
@@ -73,7 +73,7 @@ function decode(data, dh)
             for k,v in pairs(msg.Fields) do
                 msg[fields_prefix..k] = v
             end
-            msg.Fields = none
+            msg.Fields = nil
         end
         msg = {Fields=msg}
         if cfg.preserve_metadata_use_timestamp then

--- a/heka/io_modules/decoders/heka/json.lua
+++ b/heka/io_modules/decoders/heka/json.lua
@@ -70,7 +70,7 @@ function decode(data, dh)
     local msg = cjson.decode(data)
     if cfg.preserve_metadata then
         if type(msg.Fields) == "table" then
-            for k,v in pairs(msg.Fields.Fields) do
+            for k,v in pairs(msg.Fields) do
                 msg[fields_prefix..k] = v
             end
             msg.Fields = none


### PR DESCRIPTION
There is useful metadata about a message that is stored in default_headers, which is clobbered by the default heka json decoder. For the cloudops' logging pipeline it's important to preserve those fields, because they are required in order to properly route messages.