### PR TITLE
Explicitly send Content-Type header during POST in ES bulk api

### DIFF
--- a/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
+++ b/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
@@ -73,6 +73,7 @@ local pcreate_client = socket.protect(create_client);
 
 local req_headers = {
     ["user-agent"]      = http.USERAGENT,
+    ["content-type"]    = "application/x-ndjson",
     ["content-length"]  = 0,
     ["host"]            = address .. ":" .. port,
     ["accept"]          = "application/json",


### PR DESCRIPTION
  Fixes this warning returned by ES if this header is missing
  "Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header."
  see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html