### PR TITLE
Content type header

### DIFF
--- a/elasticsearch/CMakeLists.txt
+++ b/elasticsearch/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0)
-project(elasticsearch VERSION 1.0.4 LANGUAGES C)
+project(elasticsearch VERSION 1.0.5 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Elasticsearch encoders and outputs")
 set(MODULE_DEPENDENCIES heka_copy_tests rjson ep_cjson ep_socket) # fail the build if all the required modules were not specified
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${PACKAGE_PREFIX}-heka (>= 1.0), ${PACKAGE_PREFIX}-rjson (>= 1.0), ${PACKAGE_PREFIX}-cjson (>= 2.1), ${PACKAGE_PREFIX}-socket (>= 3.0)")

--- a/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
+++ b/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
@@ -73,6 +73,7 @@ local pcreate_client = socket.protect(create_client);
 
 local req_headers = {
     ["user-agent"]      = http.USERAGENT,
+    ["content-type"]    = "application/x-ndjson",
     ["content-length"]  = 0,
     ["host"]            = address .. ":" .. port,
     ["accept"]          = "application/json",


### PR DESCRIPTION
Explicitly send Content-Type header during POST in ES bulk api
    
  * Fixes this warning returned by ES if this header is missing : "Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header."
