### PR TITLE
Less restrictive values for HTTP methods

### DIFF
--- a/lpeg/modules/lpeg/common_log_format.lua
+++ b/lpeg/modules/lpeg/common_log_format.lua
@@ -130,7 +130,7 @@ local nginx_format_variables = {
     , request_completion    = l.P"OK"^-1
     --request_filename
     , request_length        = l.Ct(l.Cg(integer, "value") * l.Cg(l.Cc"B", "representation"))
-    , request_method        = l.P"GET" + "POST" + "HEAD" + "PUT" + "DELETE" + "OPTIONS" + "TRACE" + "CONNECT"
+    , request_method        = l.R"AZ"^3
     , request_time          = l.Ct(l.Cg(double, "value") * l.Cg(l.Cc"s", "representation"))
     --request_uri
     , scheme                = l.P"https" + "http"


### PR DESCRIPTION
HTTP method in logfiles can by any uppercase word with more than 3 letters. 