### PR TITLE
syslog: support for systemd sessionId starting with c (fixes #124)

### DIFF
--- a/lpeg/modules/lpeg/common_log_format.lua
+++ b/lpeg/modules/lpeg/common_log_format.lua
@@ -130,7 +130,7 @@ local nginx_format_variables = {
     , request_completion    = l.P"OK"^-1
     --request_filename
     , request_length        = l.Ct(l.Cg(integer, "value") * l.Cg(l.Cc"B", "representation"))
-    , request_method        = l.P"GET" + "POST" + "HEAD" + "PUT" + "DELETE" + "OPTIONS" + "TRACE" + "CONNECT"
+    , request_method        = (l.alnum + l.S"!#$%&'*+-.^_`|~")^1
     , request_time          = l.Ct(l.Cg(double, "value") * l.Cg(l.Cc"s", "representation"))
     --request_uri
     , scheme                = l.P"https" + "http"

--- a/lpeg/tests/common_log_format.lua
+++ b/lpeg/tests/common_log_format.lua
@@ -363,6 +363,16 @@ local function apache_vhost_combined()
     verify_result(fields, result)
 end
 
+local function apache_custom_method()
+    local grammar = clf.build_apache_grammar('%v %h %l %u %t \"%m %f %H\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"')
+    local log = '127.0.1.1 127.0.0.1 - - [20/Mar/2014:12:38:34 -0700] "Get_Script2 / HTTP/1.1" 404 492 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0"'
+    local fields = grammar:match(log)
+    local result = {
+		request_method      = "Get_Script2"
+    }
+    verify_result(fields, result)
+end
+
 local function apache_combined()
     local grammar = clf.build_apache_grammar('%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"')
     local fields = grammar:match(combined_log)
@@ -496,6 +506,7 @@ apache_formats()
 apache_custom()
 apache_clf()
 apache_vhost_combined()
+apache_custom_method()
 apache_combined()
 apache_referer()
 nginx_error()

--- a/syslog/modules/lpeg/syslog_message.lua
+++ b/syslog/modules/lpeg/syslog_message.lua
@@ -732,13 +732,13 @@ prog_grammar["sudo"] = l.Ct(
 prog_grammar["systemd-logind"] = l.Ct(
                                (
                                  l.P"New session "
-                               * l.Cg(integer, "session_id")
+                               * l.P"c"^-1 * l.Cg(integer, "session_id")
                                * l.P" of user "
                                * capture_followed_by("user_id", "." * l.P(-1))
                                * l.Cg(l.Cc("SESSION_START"), "sd_message")
                                ) + (
                                  l.P"Removed session "
-                               * l.Cg(integer, "session_id")
+                               * l.P"c"^-1 * l.Cg(integer, "session_id")
                                * l.P"."
                                * l.Cg(l.Cc("SESSION_STOP"), "sd_message")
                                * l.P(-1)

--- a/syslog/tests/syslog_message.lua
+++ b/syslog/tests/syslog_message.lua
@@ -397,6 +397,11 @@ local function systemd_logind()
     fields = grammar:match(log)
     assert(fields.sd_message == 'SESSION_STOP', fields.sd_message)
     assert(fields.session_id == 42, fields.session_id)
+
+    log = "New session c43046 of user root."
+    fields = grammar:match(log)
+    assert(fields.sd_message == 'SESSION_START', fields.sd_message)
+    assert(fields.session_id == 43046, fields.session_id)
 end
 
 local function pam()


### PR DESCRIPTION
I've kept the integer as sessionId. 