### PR TITLE
Bug 1381954: Filter out non-whitelisted experiment types and blocklisted experimen…

### DIFF
--- a/moz_telemetry/CMakeLists.txt
+++ b/moz_telemetry/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0)
-project(moz-telemetry VERSION 1.2.14 LANGUAGES C)
+project(moz-telemetry VERSION 1.2.15 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Mozilla Firefox Telemetry Data Processing")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${PACKAGE_PREFIX}-moz-ingest (>= 0.0.1), ${PACKAGE_PREFIX}-lsb (>= 1.1.0), ${PACKAGE_PREFIX}-circular-buffer (>= 1.0.2), ${PACKAGE_PREFIX}-heka (>= 1.1.9), ${PACKAGE_PREFIX}-elasticsearch (>= 1.0.3), ${PACKAGE_PREFIX}-rjson (>= 1.1.0), ${PACKAGE_PREFIX}-lfs (>= 1.6.4)")
 string(REGEX REPLACE "[()]" "" CPACK_RPM_PACKAGE_REQUIRES ${CPACK_DEBIAN_PACKAGE_DEPENDS})

--- a/moz_telemetry/tests/hindsight/run/input/moz_telemetry_s3.lua
+++ b/moz_telemetry/tests/hindsight/run/input/moz_telemetry_s3.lua
@@ -12,7 +12,8 @@ require "string"
 local inputs = {
     {Timestamp = 0, Type = "moz_telemetry_s3", Fields = { docType = "main"}},
     {Timestamp = 0, Type = "moz_telemetry_s3", Fields = { docType = "main", ["environment.experiments"] = '{"foo":{"branch":"123"}}'}},
-    {Timestamp = 0, Type = "moz_telemetry_s3", Fields = { docType = "main", ["environment.experiments"] = '{"foo":{"branch":"123"}, "bar":{"branch":"456"}}'}}
+    {Timestamp = 0, Type = "moz_telemetry_s3", Fields = { docType = "main", ["environment.experiments"] = '{"foo":{"branch":"123"}, "bar":{"branch":"456"}}'}},
+    {Timestamp = 0, Type = "moz_telemetry_s3", Fields = { docType = "main", ["environment.experiments"] = '{"foo":{"branch":"123", "type":"normandy-preference-"}, "bar":{"branch":"456", "type":"another-type"}, "pref-flip-screenshots-release-1369150":{"branch":"789"}}'}}
 }
 
 
@@ -46,9 +47,10 @@ function process_message()
         local ed = eh:read("*a")
         eh:close()
 
-        if od:match("main\n") and ed:match("main%+foo%+123") and ed:match("main%+bar%+456") then
-            check_message_count("output/moz_telemetry_s3/main", 3)
-            check_message_count("output/moz_experiments_s3/main+foo+123", 2)
+        if od:match("main\n") and ed:match("main%+foo%+123") and ed:match("main%+bar%+456")
+            and not ed:match("main%+pref-flip-screenshots-release-1369150%+789") then
+            check_message_count("output/moz_telemetry_s3/main", 4)
+            check_message_count("output/moz_experiments_s3/main+foo+123", 3)
             check_message_count("output/moz_experiments_s3/main+bar+456", 1)
             return 0
         end

--- a/moz_telemetry/tests/hindsight/run/output/moz_telemetry_s3.cfg
+++ b/moz_telemetry/tests/hindsight/run/output/moz_telemetry_s3.cfg
@@ -8,6 +8,8 @@ dimension_file  = "moz_telemetry_s3.json"
 
 -- https://bugzilla.mozilla.org/show_bug.cgi?id=1353110
 experiment_dimension_file  = "moz_telemetry_s3_experiments.json" -- optional
+experiment_types = {["normandy-preference-"] = true} -- optional
+experiment_blocklist = {["pref-flip-screenshots-release-1369150"] = true} -- optional
 
 -- directory location to store the intermediate output files
 batch_dir               = "output/moz_telemetry_s3"


### PR DESCRIPTION
…t ids in moz_telemetry_s3

I was able to get the integration tests running with a hacked-together Dockerfile (I'm considering how to generalize this and contribute it back but it'll require a little more work than I can put in at the moment.)

I have no idea where the production `moz_telemetry_s3.cfg` lives so I can add experiment_types and experiment_blocklist, but if you can point me in that direction I'll submit a PR for that as well.