### PR TITLE
add lpeg grammar for segfault logging from linux kernel

### DIFF
--- a/syslog/modules/lpeg/linux/kernel.lua
+++ b/syslog/modules/lpeg/linux/kernel.lua
@@ -157,8 +157,8 @@ local netfilter_ipv6 = l.P" SRC="
                        + netfilter_other
                        )
 
-syslog_grammar = l.Ct(
-    (
+-- Grammar for Linux NetFilter logs (e.g., iptables)
+local netfilter = (
         l.P"[" * l.Cg(sl.float, "monotonic_timestamp") * l.P"] "
         * sl.capture_until("nf_prefix", "IN=")
         * l.P"IN="
@@ -190,6 +190,20 @@ syslog_grammar = l.Ct(
             * l.P" "
             )^-1
         )
-    )
+
+-- Grammar for kernel generated segfault messages
+local segfault = (
+        l.P"[" * l.Cg(sl.float, "monotonic_timestamp") * l.P"] "
+        * sl.capture_until("fault_process_name", "[") * l.P("[")
+        * sl.capture_until("fault_process_pid", "]") * l.P("]: ")
+        * l.Cg(l.P("segfault"), "fault_type")
+        * l.P(" at ") * l.Cg(sl.integer, "fault_at")
+        * l.P(" ip ") * l.Cg(sl.notspace, "fault_instruction_pointer")
+        * l.P(" sp ") * l.Cg(sl.notspace, "fault_stack_pointer")
+        * l.P(" error ") * l.Cg(sl.integer, "fault_error_bits")
+        * l.P(" in ") * l.Cg(sl.notspace, "fault_in")
+        )
+
+syslog_grammar = l.Ct(netfilter + segfault)
 
 return M

--- a/syslog/tests/linux/kernel.lua
+++ b/syslog/tests/linux/kernel.lua
@@ -128,3 +128,16 @@ assert(fields.nf_protocol == 'UDP', fields.nf_protocol)
 assert(fields.nf_spt == 54989, fields.nf_spt)
 assert(fields.nf_dpt == 1947, fields.nf_dpt)
 assert(fields.nf_udp_len == 48, fields.nf_udp_len)
+
+--- Test segfault message processing
+log = "[1994647.950748] test[28779]: segfault at 1 ip 000034421bfaaa46 sp 00007fffffffffff error 4 in libc-2.29.so[7ffffffff000+1c0000]"
+fields = grammar:match(log)
+assert(fields.monotonic_timestamp == 1994647.950748, fields.monotonic_timestamp)
+assert(fields.fault_process_name == 'test', fields.fault_process_name)
+assert(fields.fault_process_pid == '28779', fields.fault_process_pid)
+assert(fields.fault_type == 'segfault', fields.fault_type)
+assert(fields.fault_at == 1, fields.fault_at)
+assert(fields.fault_instruction_pointer == '000034421bfaaa46', fields.fault_instruction_pointer)
+assert(fields.fault_stack_pointer == '00007fffffffffff', fields.fault_stack_pointer)
+assert(fields.fault_error_bits == 4, fields.fault_error_bits)
+assert(fields.fault_in == 'libc-2.29.so[7ffffffff000+1c0000]', fields.fault_in)


### PR DESCRIPTION
Extends original kernel grammar which handled netfilter logs to also
handle parsing segfault messages.