### PR TITLE
io_module to extend heka message with GeoIP information

### DIFF
--- a/geoip/CMakeLists.txt
+++ b/geoip/CMakeLists.txt
@@ -9,7 +9,7 @@ externalproject_add(
     ep_geoip
     GIT_REPOSITORY https://github.com/agladysh/lua-geoip.git
     GIT_TAG 06548fd6dac30d4ba0ea5489c3cffe8c20b526c0
-    CMAKE_ARGS ${EP_CMAKE_ARGS}
+    CMAKE_ARGS ${EP_CMAKE_ARGS} -DPARENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
     UPDATE_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.${PROJECT_NAME} <SOURCE_DIR>/CMakeLists.txt
 )
 externalproject_add_step(ep_geoip copy_cpack 

--- a/geoip/CMakeLists.txt.geoip
+++ b/geoip/CMakeLists.txt.geoip
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(geoip VERSION 0.2.0 LANGUAGES C)
+project(geoip VERSION 0.2.1 LANGUAGES C)
 
 set(CPACK_PACKAGE_NAME luasandbox-${PROJECT_NAME})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lua geoip Module")
@@ -85,3 +85,5 @@ install(TARGETS city DESTINATION ${INSTALL_IOMODULE_PATH}/geoip)
 add_library(country SHARED ${COUNTRY_SRC})
 target_link_libraries(country ${LUA_LIBRARIES} ${GEOIP_LIBRARY})
 install(TARGETS country DESTINATION ${INSTALL_IOMODULE_PATH}/geoip)
+
+install(DIRECTORY ${PARENT_SOURCE_DIR}/io_modules/ DESTINATION ${INSTALL_IOMODULE_PATH} ${DPERMISSION})

--- a/geoip/io_modules/geoip/geo_append.lua
+++ b/geoip/io_modules/geoip/geo_append.lua
@@ -1,0 +1,153 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+# Heka Message Extensions with GeoIP information
+
+This module is intended to be used with another IO module such as a decoder to extend
+the message with GeoIP information prior to injection.
+
+## Functions
+
+### geo_append
+
+Given a message, attempt to geolocate any fields (specified by the fields configuration
+option). The lookup configuration option specifies the types of location that will occur.
+
+Valid key values for the lookup configuration option include options that would be passed as
+a lookup type to the geoip query_by_addr function. The current list of valid options can be
+seen at https://github.com/agladysh/lua-geoip/blob/master/src/city.c in the opts variable,
+common values will include "city" and "country_code".
+
+For example, if "remote_addr" is present in fields, and lookup is "{ city = "city" }", if
+we can geolocate the address a new field will be added called remote_addr_city which contains
+the results of the geolocation.
+
+*Arguments*
+- msg (table) - original message
+
+*Return*
+- msg (table) - message possibly modified with new fields
+
+## Configuration examples
+```lua
+geo_append = {
+    path = "/path/to/geo/dat", -- path to GeoIP data
+    test = false, -- true if being used in tests without GeoIP database
+    fields = { "remote_addr" }, -- Fields to attempt to geolocate
+    lookup = { city = "city", country_code = "country" }, -- lookup types
+}
+```
+--]]
+
+local geoip     = require "geoip.city"
+local ostime    = require "os".time
+local floor     = require "math".floor
+local sformat   = require "string".format
+local slen      = string.len
+local smatch    = string.match
+
+local module_name = ...
+local module_cfg = require "string".gsub(module_name, "%.", "_")
+local config = read_config(module_cfg) or error("geo_append configuration not found")
+
+local assert    = assert
+local pairs     = pairs
+local error     = error
+local pcall     = pcall
+
+local M = {}
+setfenv(1, M) -- Remove external access to contain everything in the module.
+
+local gtest = {}
+
+-- In test mode, returns Mountain View, US for 192.168.1.2 otherwise nil, only
+-- supports country_code and city lookup values
+function gtest:query_by_addr(v, lookup)
+    if v ~= "192.168.1.2" then
+        return nil
+    end
+    if lookup == "country_code" then
+        return "US"
+    elseif lookup == "city" then
+        return "Mountain View"
+    end
+    return nil
+end
+
+local function geo_query(f, p)
+    return config.geoip:query_by_addr(f, p)
+end
+
+local function geo_config()
+    if not config.test then
+        config.geoip = assert(geoip.open(config.path))
+    else
+        config.geoip = gtest
+    end
+    if not config.lookup then
+        error("geo_append configuration contains no lookup option")
+    end
+    if not config.fields then
+        error("geo_append configuration contains no fields option")
+    end
+    local c = 0
+    for k,v in pairs(config.fields) do
+        c = c + 1
+    end
+    if c == 0 then
+        error("geo_append configuration contains no fields")
+    end
+    config.hour = floor(ostime() / 3600)
+    return config
+end
+
+local function geo_refresh()
+    if config.test then
+        return
+    end
+    local chour = floor(ostime() / 3600)
+    if chour > config.hour then
+        config.geoip:close()
+        config.geoip = assert(geoip.open(config.path))
+        config.hour = chour
+    end
+end
+
+local function geo_validate(ip)
+    local sl = slen(ip)
+    if sl < 7 or sl > 15 or not smatch(ip, "^%d+%.%d+%.%d+%.%d+$") then
+        return false
+    end
+    return true
+end
+
+geo_config()
+
+function geo_append(msg)
+    geo_refresh()
+
+    if not msg.Fields then
+        return msg
+    end
+
+    local omsg = msg
+    for k,v in pairs(config.fields) do
+        if omsg.Fields[v] then
+            if geo_validate(omsg.Fields[v]) then
+                for ik, iv in pairs(config.lookup) do
+                    local ks = sformat("%s_%s", v, iv)
+                    local s, ret = pcall(geo_query, omsg.Fields[v], ik)
+                    if s and ret then
+                        msg.Fields[ks] = ret
+                    end
+                end
+            end
+        end
+    end
+
+    return msg
+end
+
+return M

--- a/moz_security/sandboxes/heka/analysis/moz_security_sshd_login_monitor.lua
+++ b/moz_security/sandboxes/heka/analysis/moz_security_sshd_login_monitor.lua
@@ -33,10 +33,16 @@ local msg = {
 }
 
 function process_message()
-    local user  = read_message("Fields[remote_user]")
-    local ip    = read_message("Fields[remote_addr]")
+    local user    = read_message("Fields[remote_user]")
+    local ip      = read_message("Fields[remote_addr]")
+    local city    = read_message("Fields[remote_addr_city]")
+    local country = read_message("Fields[remote_addr_country]")
 
     msg.Fields[2].value    = string.format("%s logged into bastion from %s", user, ip)
+    -- If we also have city and country information, append that to the message
+    if city and country then
+        msg.Fields[2].value = msg.Fields[2].value .. string.format(" (%s, %s)", city, country)
+    end
     msg.Fields[3].value[2] = string.format("<manatee-%s@moz-svc-ops.pagerduty.com>", user)
     inject_message(msg)
     return 0

--- a/moz_security/tests/hindsight/run/input/generate_sshd.cfg
+++ b/moz_security/tests/hindsight/run/input/generate_sshd.cfg
@@ -1,1 +1,8 @@
 filename = "generate_sshd.lua"
+
+geoip_geo_append = {
+    path = "/nonexistent",
+    test = true,
+    fields = { "nonexistent", "remote_addr" },
+    lookup = { city = "city", country_code = "country" },
+}

--- a/moz_security/tests/hindsight/run/input/generate_sshd.lua
+++ b/moz_security/tests/hindsight/run/input/generate_sshd.lua
@@ -8,8 +8,11 @@
 
 
 local tests = {
-    {"11111111-1111-1111-1111-111111111111", "trink" , "192.168.1.1"},
+    {"11111111-1111-1111-1111-111111111111", "trink", "192.168.1.1"},
+    {"11111111-1111-1111-1111-111111111112", "trink", "192.168.1.2"}
 }
+
+ga = require "geoip.geo_append"
 
 local msg = {
     Timestamp = nil,
@@ -27,6 +30,7 @@ function process_message()
         msg.Uuid = v[1]
         msg.Fields.remote_user = v[2]
         msg.Fields.remote_addr = v[3]
+        msg = ga.geo_append(msg)
         inject_message(msg)
     end
     return 0

--- a/moz_security/tests/hindsight/run/output/sshd_login_verification.lua
+++ b/moz_security/tests/hindsight/run/output/sshd_login_verification.lua
@@ -11,7 +11,10 @@ require "string"
 local results = {
     { summary    = "trink logged into bastion from 192.168.1.1",
       recipients = {"<foxsec-dump+OutOfHours@mozilla.com>", "<manatee-trink@moz-svc-ops.pagerduty.com>"}
-    }
+    },
+    { summary    = "trink logged into bastion from 192.168.1.2 (Mountain View, US)",
+      recipients = {"<foxsec-dump+OutOfHours@mozilla.com>", "<manatee-trink@moz-svc-ops.pagerduty.com>"}
+    },
 }
 
 local cnt = 0
@@ -37,5 +40,5 @@ end
 
 
 function timer_event()
-    assert(cnt == 1, string.format("%d out of 1 tests ran", cnt))
+    assert(cnt == 2, string.format("%d out of 2 tests ran", cnt))
 end


### PR DESCRIPTION
Intended to be used with other io_modules such as decoders; extends
existing message with GeoIP information for any fields that match an
IPv4 address expression. The GeoIP information is added with a postfix
along side the original field value.

Resolves #190