### PR TITLE
Add an apache log decoder

### DIFF
--- a/lpeg/io_modules/decoders/apache/access.lua
+++ b/lpeg/io_modules/decoders/apache/access.lua
@@ -1,0 +1,95 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+# Apache Access Log Decoder Module
+
+## Decoder Configuration Table (required)
+
+```lua
+decoders_apache_access = {
+  -- The ‘log_format’ configuration directive from the apache.conf.
+  -- The $time_local or $time_iso8601 variable is converted to the number of
+  -- nanosecond  since the Unix epoch and used to set the Timestamp on the message.
+  -- http://apache.org/en/docs/http/ngx_http_log_module.html
+  log_format = '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"',
+
+  -- Transform the http_user_agent into user_agent_browser, user_agent_version, user_agent_os.
+  user_agent_transform = false, -- default
+
+  -- Always preserve the http_user_agent value if transform is enabled.
+  user_agent_keep = false, -- default
+
+  -- Only preserve the http_user_agent value if transform is enabled and fails.
+  user_agent_conditional = false, -- default
+
+  -- Always preserve the original log line in the message payload.
+  payload_keep = false, -- default
+}
+```
+
+## Functions
+
+### decode
+
+Decode and inject the resulting message
+
+*Arguments*
+- data (string) - Apache access log line
+- default_headers (table/nil/none) - Heka message table containing the default
+  header values to use, if they are not populated by the decoder. If 'Fields'
+  is specified it should be in the hashed based format see:
+  http://mozilla-services.github.io/lua_sandbox/heka/message.html. In the case
+  of multiple decoders this may be the message from the previous input/decoding
+  step.
+- mutable (bool/nil/none) - Flag indicating if the decoder can modify the
+  default_headers/msg structure in place or if it has to be copied first.
+
+*Return*
+- err (nil, string) or throws an error on invalid data or an inject message
+  failure
+    - nil - if the decode was successful
+    - string - error message if the decode failed (e.g. no match)
+
+--]]
+
+-- Imports
+local module_name   = ...
+local module_cfg    = require "string".gsub(module_name, "%.", "_")
+local sdu           = require "lpeg.sub_decoder_util"
+local clf           = require "lpeg.common_log_format"
+
+local inject_message = inject_message
+
+local cfg = read_config(module_cfg)
+assert(type(cfg) == "table", module_cfg .. " must be a table")
+local grammar = clf.build_apache_grammar(cfg.log_format)
+
+local M = {}
+setfenv(1, M) -- Remove external access to contain everything in the module
+
+
+function decode(data, dh, mutable)
+    local fields = grammar:match(data)
+    if not fields then return "parse failed" end
+
+    local msg = sdu.copy_message(dh, mutable)
+    if cfg.payload_keep then msg.Payload = data end
+
+    if fields.http_user_agent and cfg.user_agent_transform then
+        fields.user_agent_browser,
+        fields.user_agent_version,
+        fields.user_agent_os = clf.normalize_user_agent(fields.http_user_agent)
+        if not ((cfg.user_agent_conditional and not fields.user_agent_browser) or cfg.user_agent_keep) then
+            fields.http_user_agent = nil
+        end
+    end
+
+    msg.Timestamp = fields.time
+    fields.time = nil
+    sdu.add_fields(msg, fields)
+    inject_message(msg)
+end
+
+return M

--- a/lpeg/io_modules/decoders/apache/error.lua
+++ b/lpeg/io_modules/decoders/apache/error.lua
@@ -1,0 +1,63 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+# Apache Error Log Decoder Module
+
+## Decoder Configuration Table
+- none
+
+## Functions
+
+### decode
+
+Decode and inject the resulting message
+
+*Arguments*
+- data (string) - Raw data from the input sandbox that needs
+  parsing/decoding/transforming
+- default_headers (table/nil/none) - Heka message table containing the default
+  header values to use, if they are not populated by the decoder. If 'Fields'
+  is specified it should be in the hashed based format see:
+  http://mozilla-services.github.io/lua_sandbox/heka/message.html. In the case
+  of multiple decoders this may be the message from the previous input/decoding
+  step.
+- mutable (bool/nil/none) - Flag indicating if the decoder can modify the
+  default_headers/msg structure in place or if it has to be copied first.
+
+*Return*
+- err (nil, string) or throws an error on invalid data or an inject message
+  failure
+    - nil - if the decode was successful
+    - string - error message if the decode failed (e.g. no match)
+
+--]]
+
+-- Imports
+local sdu       = require "lpeg.sub_decoder_util"
+local grammar   = require "lpeg.common_log_format".apache_error_grammar
+
+local inject_message = inject_message
+
+local M = {}
+setfenv(1, M) -- Remove external access to contain everything in the module
+
+function decode(data, dh, mutable)
+    local fields = grammar:match(data)
+    if not fields then return "parse failed" end
+
+    local msg = sdu.copy_message(dh, mutable)
+    msg.Timestamp = fields.time
+    msg.Payload   = fields.msg
+    msg.Severity  = fields.severity
+    msg.Pid       = fields.pid
+    fields.time     = nil
+    fields.msg      = nil
+    fields.severity = nil
+    fields.pid      = nil
+    sdu.add_fields(msg, fields)
+    inject_message(msg)
+end
+
+return M

--- a/lpeg/modules/lpeg/common_log_format.lua
+++ b/lpeg/modules/lpeg/common_log_format.lua
@@ -481,4 +481,11 @@ nginx_error_grammar = l.Ct(l.Cg(dt.build_strftime_grammar("%Y/%m/%d %T") / dt.ti
                            * (l.P"*" * l.Cg(l.digit^1 / tonumber, "connection") * " ")^-1
                            * l.Cg(l.P(1)^0, "msg"))
 
+apache_error_grammar = l.Ct("[" * l.Cg(dt.build_strftime_grammar("%a %b %d %T.%f %Y") / dt.time_to_ns, "time") * "]"
+                           * l.space * "[" * ( l.Cg( (l.alnum + l.S"_-")^1, "process_name" )  )^-1 * ":" * nginx_error_levels * "]"
+                           * l.space * "[pid" * l.space * l.Cg(l.digit^1 / tonumber, "pid") * ":tid" * l.space
+                           * l.Cg(l.digit^1 / tonumber, "tid") * "]" * l.space
+                           * (l.P"[client" * l.space * l.Cg(host, "remote_addr") * ":" * l.Cg(l.digit^1 / tonumber, "port") * "]" )^-1
+                           * l.Cg(l.P(1)^0, "msg"))
+
 return M


### PR DESCRIPTION
Extend the lpeg common_log_format to include apache error log format and provide apache log based decoders based on provided LogFormat parser