### PR TITLE
Issues 332, 333 - Call Get() before Create()

### DIFF
--- a/gcp/CMakeLists.txt
+++ b/gcp/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.6)
-project(gcp VERSION 0.0.1 LANGUAGES C CXX)
+project(gcp VERSION 0.0.2 LANGUAGES C CXX)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GCP Lua Modules")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "luasandbox-lpeg (>= 1.0.9)")
 string(REGEX REPLACE "[()]" "" CPACK_RPM_PACKAGE_REQUIRES ${CPACK_DEBIAN_PACKAGE_DEPENDS})

--- a/gcp/pubsub.md
+++ b/gcp/pubsub.md
@@ -25,7 +25,7 @@ local sub = gcp.pubsub.subscriber(channel, topic, subscription_name, max_async_r
 
 *Arguments*
 * channel (string) e.g. "pubsub.googleapis.com"
-* topic (string) e.g. "projects/MyProject/topics/MyTopic"
+* topic (string) e.g. "projects/MyProject/topics/MyTopic" -- used to validate the subscription topic or create the subscription if necessary
 * subscription_name (string) e.g. "MySubscription"
 * max_async_requests (integer) Defaults to 20 (0 synchronous only)
 


### PR DESCRIPTION
The initial version simply called 'create' and ignored an already exists error.
However, that requires more permissions, so now a 'get' is attempted and if
that fails with a not found error then create is tried.

An error is now generated if the subscription topic does not match the specified
topic, this is a safety check to prevent confusion in the case where the subscription
name is already in use on another topic.