### PR TITLE
Support multiple matchers per field for cloudtrail

### DIFF
--- a/moz_security/sandboxes/heka/analysis/moz_security_cloudtrail.lua
+++ b/moz_security/sandboxes/heka/analysis/moz_security_cloudtrail.lua
@@ -48,7 +48,7 @@ events = {
             { "eventSource", "^iam.amazonaws.com$" },
             { "recipientAccountId", "^1234567890$", "^1122954321$" },
             { "userIdentity.invokedBy", "^signin.amazonaws.com$" },
-            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "[^true]" }
+            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "^false$" }
         }
     }
 }
@@ -124,6 +124,7 @@ function process_message()
               while field[i] do
                 if string.match(det[field[1]], field[i]) then
                     match_counter = match_counter + 1
+                    break
                 end
                 i = i + 1
               end

--- a/moz_security/sandboxes/heka/analysis/moz_security_cloudtrail.lua
+++ b/moz_security/sandboxes/heka/analysis/moz_security_cloudtrail.lua
@@ -46,9 +46,9 @@ events = {
         description = "IAM action in production account from console without mfa",
         fields = {
             { "eventSource", "^iam.amazonaws.com$" },
-            { "recipientAccountId", "^1234567890$" },
+            { "recipientAccountId", "^1234567890$", "^1122954321$" },
             { "userIdentity.invokedBy", "^signin.amazonaws.com$" },
-            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "^false$" }
+            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "[^true]" }
         }
     }
 }
@@ -119,9 +119,14 @@ function process_message()
             end
 
             if det[field[1]] then
-                if string.match(det[field[1]], field[2]) then
+              -- All items in the event field after the first one are potential matches
+              local i = 2
+              while field[i] do
+                if string.match(det[field[1]], field[i]) then
                     match_counter = match_counter + 1
                 end
+                i = i + 1
+              end
             end
         end
 

--- a/moz_security/tests/integration/analysis_cloudtrail/run/analysis/cloudtrail.cfg
+++ b/moz_security/tests/integration/analysis_cloudtrail/run/analysis/cloudtrail.cfg
@@ -21,7 +21,7 @@ events = {
             { "eventSource", "^iam.amazonaws.com$" },
             { "recipientAccountId", "^1122334455$", "^1234567890$" },
             { "userIdentity.invokedBy", "^signin.amazonaws.com$" },
-            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "[^true]" }
+            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "^false$" }
         }
     }
 }

--- a/moz_security/tests/integration/analysis_cloudtrail/run/analysis/cloudtrail.cfg
+++ b/moz_security/tests/integration/analysis_cloudtrail/run/analysis/cloudtrail.cfg
@@ -19,16 +19,17 @@ events = {
         description = "IAM action in production account from console without mfa",
         fields = {
             { "eventSource", "^iam.amazonaws.com$" },
-            { "recipientAccountId", "^1234567890$" },
+            { "recipientAccountId", "^1122334455$", "^1234567890$" },
             { "userIdentity.invokedBy", "^signin.amazonaws.com$" },
-            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "^false$" }
+            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "[^true]" }
         }
     }
 }
 
 aws_account_mapping = {
     ["5555555555"] = "dev",
-    ["1234567890"] = "prod"
+    ["1234567890"] = "prod",
+    ["1122334455"] = "prod2"
 }
 
 alert = {


### PR DESCRIPTION
This is particularly useful for when matching against multiple aws account ids. As well, in moz_security_cloudtrail we are currently using `string.match` which does not have an `or` operator.

As well, this PR adds an example of a `not` operation within `string.match`.