### PR TITLE
Use lpeg.re for matching in cloudtrail sandbox

### DIFF
--- a/moz_security/tests/integration/analysis_cloudtrail/run/analysis/cloudtrail.cfg
+++ b/moz_security/tests/integration/analysis_cloudtrail/run/analysis/cloudtrail.cfg
@@ -13,16 +13,16 @@ events = {
         description = "access key created",
         resource = "requestParameters.userName",
         fields = {
-            { "eventName", "^CreateAccessKey$" }
+            { "eventName", "'CreateAccessKey' !." }
         }
     },
     {
         description = "IAM action in production account from console without mfa",
         fields = {
-            { "eventSource", "^iam.amazonaws.com$" },
-            { "recipientAccountId", "^1122334455$", "^1234567890$" },
-            { "userIdentity.invokedBy", "^signin.amazonaws.com$" },
-            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "^false$" }
+            { "eventSource", "'iam.amazonaws.com' !." },
+            { "recipientAccountId", "('1122334455' / '1234567890') !." },
+            { "userIdentity.invokedBy", "'signin.amazonaws.com' !." },
+            { "userIdentity.sessionContext.attributes.mfaAuthenticated", "!('true' !.)" }
         }
     }
 }


### PR DESCRIPTION
Switch to using lpeg.re within cloudtrail analysis sandbox so that field
matchers can be more expressive. Also allows for the removal of logic
supporting multiple matchers against an event field.

r? @ameihm0912 @trink 