### PR TITLE
Extract usernames from Taskcluster audit logs

### DIFF
--- a/moz_security/io_modules/taskcluster.lua
+++ b/moz_security/io_modules/taskcluster.lua
@@ -59,7 +59,7 @@ function add_username(msg, field_name)
     for _, matcher in ipairs(cfg.matchers) do
       username = re.match(clientid, matcher)
       if username then
-        msg.Fields["username"] = username
+        msg.Fields[username_field] = username
         break
       end
     end

--- a/moz_security/io_modules/taskcluster.lua
+++ b/moz_security/io_modules/taskcluster.lua
@@ -33,7 +33,7 @@ taskcluster = {
 }
 decoder_module = {
     {
-        { "decoders.heka.table_to_fields" },
+        "decoders.heka.table_to_fields",
         { clientid = "taskcluster#add_username"}
     }
 }

--- a/moz_security/io_modules/taskcluster.lua
+++ b/moz_security/io_modules/taskcluster.lua
@@ -1,0 +1,51 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+# Heka Message Extensions for Taskcluster
+
+This module is intended to be used with another IO module such as a decoder to
+add a username field if the client is a human user.
+
+## Functions
+
+### add_username
+
+Given a Heka message with a Taskcluster clientid, attempt to parse out the username
+associated with the clientid. This is currently specific to Mozilla LDAP usernames,
+as that is the primary way in which human users authenticate with Taskcluster. If no
+username is found, do nothing.
+
+*Arguments*
+- msg (table) - original message
+- field_name (string) - field name in the message to lookup
+
+*Return*
+- none - the message is modified in place if a username is found
+
+## Configuration examples
+decoder_module = {
+    {
+        { "decoders.heka.table_to_fields" },
+        { clientid = "taskcluster#add_username"}
+    }
+}
+--]]
+
+local re = require "re"
+
+local M = {}
+setfenv(1, M)
+
+function add_username(msg, field_name)
+    if not msg.Fields then return end
+    local clientid = msg.Fields[field_name]
+
+    username = re.match(clientid, "'mozilla-auth0/ad|Mozilla-LDAP|' (s <- {%w+}) '/'")
+    if username then
+      msg.Fields["username"] = username
+    end
+end
+
+return M

--- a/moz_security/io_modules/taskcluster.lua
+++ b/moz_security/io_modules/taskcluster.lua
@@ -25,7 +25,7 @@ username is found, do nothing.
 - none - the message is modified in place if a username is found
 
 ## Configuration examples
-taskcluster_decoder = {
+taskcluster = {
     username_field = "username",
     matchers = {
       "'mozilla-auth0/ad|Mozilla-LDAP|' (s <- {%w+}) '/'"
@@ -39,7 +39,7 @@ decoder_module = {
 }
 --]]
 
-local module_name = "taskcluster_decoder"
+local module_name = ...
 local cfg         = read_config(module_name) or error(module_name .. " configuration not found")
 assert(type(cfg.matchers) == "table", "matchers configuration must be a table")
 

--- a/moz_security/test_sandbox.c
+++ b/moz_security/test_sandbox.c
@@ -55,11 +55,23 @@ static char* test_iputils()
   return NULL;
 }
 
+static char* test_taskcluster()
+{
+  lsb_lua_sandbox *sb = lsb_create(NULL, "taskcluster.lua",
+                                   TEST_MODULE_PATH "\nlog_level = 7", &logger);
+  mu_assert(sb, "lsb_create() received: NULL");
+  lsb_err_value ret = lsb_init(sb, NULL);
+  mu_assert(!ret, "lsb_init() received: %s %s", ret, lsb_get_error(sb));
+  e = lsb_destroy(sb);
+  mu_assert(!e, "lsb_destroy() received: %s", e);
+  return NULL;
+}
 
 static char* all_tests()
 {
   mu_run_test(test_hawk);
   mu_run_test(test_iputils);
+  mu_run_test(test_taskcluster);
   return NULL;
 }
 

--- a/moz_security/tests/taskcluster.lua
+++ b/moz_security/tests/taskcluster.lua
@@ -2,6 +2,19 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+local cfg = {
+    taskcluster_decoder = {
+        username_field = "username",
+        matchers = {
+          "'mozilla-auth0/ad|Mozilla-LDAP|' (s <- {%w+}) '/'"
+        }
+    }
+}
+
+function read_config(k)
+    return cfg[k]
+end
+
 local taskcluster = require "taskcluster"
 local string = require "string"
 

--- a/moz_security/tests/taskcluster.lua
+++ b/moz_security/tests/taskcluster.lua
@@ -3,7 +3,7 @@
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 local cfg = {
-    taskcluster_decoder = {
+    taskcluster = {
         username_field = "username",
         matchers = {
           "'mozilla-auth0/ad|Mozilla-LDAP|' (s <- {%w+}) '/'"

--- a/moz_security/tests/taskcluster.lua
+++ b/moz_security/tests/taskcluster.lua
@@ -1,0 +1,21 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+local taskcluster = require "taskcluster"
+local string = require "string"
+
+data = {
+  {{ Fields = { clientid = "no-user-name" } }, nil},
+  {{ Fields = { clientid = "mozilla-auth0/ad|Mozilla|almost/" } }, nil},
+  {{ Fields = { clientid = "mozilla-auth0/ad|Mozilla|almost/again" } }, nil},
+  {{ Fields = { clientid = "mozilla-auth0/ad|Mozilla-LDAP|picard/" } }, "picard"},
+  {{ Fields = { clientid = "mozilla-auth0/ad|Mozilla-LDAP|picard/test" } }, "picard"},
+}
+
+for i, msg in ipairs(data) do
+  taskcluster.add_username(msg[1], "clientid")
+
+  errmsg = string.format("test cnt:%d failed. %s != %s", i, tostring(msg[1].Fields["username"]), tostring(msg[2]))
+  assert(msg[1].Fields["username"] == msg[2], errmsg)
+end


### PR DESCRIPTION
Adds the `taskcluster#add_username` func that can be used with another
decoder to extract the ldap username from a taskcluster clientid. This
makes plugging into other analysis sandboxes much simpler.

Blocked by https://github.com/mozilla-services/lua_sandbox_extensions/issues/381
r? @ameihm0912 