### PR TITLE
Add support for appending an alert email footer

### DIFF
--- a/socket/CMakeLists.txt.socket
+++ b/socket/CMakeLists.txt.socket
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(socket VERSION 3.0.8 LANGUAGES C)
+project(socket VERSION 3.0.9 LANGUAGES C)
 
 set(CPACK_PACKAGE_NAME luasandbox-${PROJECT_NAME})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lua Socket Modules")

--- a/socket/io_modules/alert/email.lua
+++ b/socket/io_modules/alert/email.lua
@@ -121,6 +121,9 @@ local content = {
 function send(msg, mcfg)
     content.headers.subject = msg.Fields[2].value[1]
     content.body = msg.Payload
+    if type(mcfg.footer) == "string" then
+        content.body = content.body .. mcfg.footer
+    end
 
     email.rcpt      = mcfg.recipients
     email.user      = cfg.user

--- a/socket/modules/heka/alert/email.lua
+++ b/socket/modules/heka/alert/email.lua
@@ -14,7 +14,8 @@ email distribution list.
 alert = {
     modules = {
         email = {
-            recipients = {"foo@example.com"}
+            recipients = {"foo@example.com"},
+	    -- footer = "example footer" -- optional
         }
     }
 }


### PR DESCRIPTION
This is an optional field in the config that if set to a string appends said string to the footer of alert emails.