### PR TITLE
Allow heka_tcp output to drop messages on connection/send failures

### DIFF
--- a/socket/CMakeLists.txt.socket
+++ b/socket/CMakeLists.txt.socket
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(socket VERSION 3.0.10 LANGUAGES C)
+project(socket VERSION 3.0.11 LANGUAGES C)
 
 set(CPACK_PACKAGE_NAME luasandbox-${PROJECT_NAME})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lua Socket Modules")


### PR DESCRIPTION
This feature allows data to be sent to an unreliable endpoint without
backpressuring the system. The delivery is simply best effort.