### PR TITLE
Implement payload_keep option for subdecoders

### DIFF
--- a/syslog/CMakeLists.txt
+++ b/syslog/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0)
-project(syslog VERSION 1.0.12 LANGUAGES C)
+project(syslog VERSION 1.0.13 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Syslog parsers and collectors")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${PACKAGE_PREFIX}-lpeg (>= 1.0.9), ${PACKAGE_PREFIX}-socket (>= 3.0)")
 string(REGEX REPLACE "[()]" "" CPACK_RPM_PACKAGE_REQUIRES ${CPACK_DEBIAN_PACKAGE_DEPENDS})

--- a/syslog/io_modules/decoders/syslog.lua
+++ b/syslog/io_modules/decoders/syslog.lua
@@ -13,7 +13,7 @@ decoders_syslog = {
   -- see https://github.com/rsyslog/rsyslog/blob/de0a9dd10703c4e6efcc69164781220d31a9e115/runtime/rsconf.c#L85
   -- Default:
   -- template = "<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag:1:32%%msg:::sp-if-no-1st-sp%%msg%", -- RSYSLOG_TraditionalForwardFormat
-  -- payload_keep = false, -- Flag indicating if the original payload should be kept when using sub_decoders
+  -- keep_data = nil, -- Flag indicating if the complete input in the returned data, and how to name that field.
 
   -- printf_messages = nil, -- see: https://mozilla-services.github.io/lua_sandbox_extensions/lpeg/modules/lpeg/
   -- sub_decoders = nil, -- see: https://mozilla-services.github.io/lua_sandbox_extensions/lpeg/io_modules/lpeg/sub_decoder_util.html
@@ -54,6 +54,9 @@ local sdu           = require "lpeg.sub_decoder_util"
 
 local cfg = read_config(module_cfg) or {}
 assert(type(cfg) == "table", module_cfg .. " must be a table")
+if cfg.keep_data then
+    assert(type(cfg.keep_data) == "string", "keep_data must be nil, or a string")
+end
 local template      = cfg.template or "<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag:1:32%%msg:::sp-if-no-1st-sp%%msg%"
 local grammar       = syslog.build_rsyslog_grammar(template)
 local sub_decoders  = sdu.load_sub_decoders(cfg.sub_decoders, cfg.printf_messages)
@@ -104,10 +107,13 @@ function decode(data, dh, mutable)
     fields.msg = nil
     sdu.add_fields(msg, fields)
 
+    if cfg.keep_data ~= nil then
+        sdu.add_fields(msg, { [cfg.keep_data] = data })
+    end
+
+
     local df = sub_decoders[programname]
     if df then
-        if cfg.payload_keep then msg.Payload = data end
-
         local err = df(payload, msg, true)
         if err then
             err = string.format("%s.%s %s", module_name, programname, err)

--- a/syslog/io_modules/decoders/syslog.lua
+++ b/syslog/io_modules/decoders/syslog.lua
@@ -13,6 +13,7 @@ decoders_syslog = {
   -- see https://github.com/rsyslog/rsyslog/blob/de0a9dd10703c4e6efcc69164781220d31a9e115/runtime/rsconf.c#L85
   -- Default:
   -- template = "<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag:1:32%%msg:::sp-if-no-1st-sp%%msg%", -- RSYSLOG_TraditionalForwardFormat
+  -- payload_keep = false, -- Flag indicating if the original payload should be kept when using sub_decoders
 
   -- printf_messages = nil, -- see: https://mozilla-services.github.io/lua_sandbox_extensions/lpeg/modules/lpeg/
   -- sub_decoders = nil, -- see: https://mozilla-services.github.io/lua_sandbox_extensions/lpeg/io_modules/lpeg/sub_decoder_util.html
@@ -105,6 +106,8 @@ function decode(data, dh, mutable)
 
     local df = sub_decoders[programname]
     if df then
+        if cfg.payload_keep then msg.Payload = data end
+
         local err = df(payload, msg, true)
         if err then
             err = string.format("%s.%s %s", module_name, programname, err)

--- a/syslog/io_modules/decoders/syslog.lua
+++ b/syslog/io_modules/decoders/syslog.lua
@@ -102,15 +102,11 @@ function decode(data, dh, mutable)
     msg.Hostname = fields.hostname or fields.source
     fields.hostname = nil
     fields.source = nil
+    if cfg.keep_data then fields[cfg.keep_data] = data end
 
     local payload = fields.msg
     fields.msg = nil
     sdu.add_fields(msg, fields)
-
-    if cfg.keep_data ~= nil then
-        sdu.add_fields(msg, { [cfg.keep_data] = data })
-    end
-
 
     local df = sub_decoders[programname]
     if df then

--- a/syslog/tests/integration/tutorial/run/analysis/verify_grammar_module_keep.cfg
+++ b/syslog/tests/integration/tutorial/run/analysis/verify_grammar_module_keep.cfg
@@ -1,0 +1,2 @@
+filename = "verify_grammar_module_keep.lua"
+message_matcher = "Logger == 'input.grammar_module_keep'"

--- a/syslog/tests/integration/tutorial/run/analysis/verify_grammar_module_keep.lua
+++ b/syslog/tests/integration/tutorial/run/analysis/verify_grammar_module_keep.lua
@@ -12,8 +12,8 @@ local messages = {
         Logger = "input.grammar_module_keep",
         Hostname = "ubuntu",
         Pid = 3453,
-        Payload = 'Feb 14 19:20:21 ubuntu someapp[3453]: foo=bar a=14 baz="hello kitty" cool%story=bro f %^asdf ip=216.160.83.56',
         Fields = {
+            ["@message"] = 'Feb 14 19:20:21 ubuntu someapp[3453]: foo=bar a=14 baz="hello kitty" cool%story=bro f %^asdf ip=216.160.83.56',
             a = "14",
             foo = "bar",
             ["cool%story"] = "bro",

--- a/syslog/tests/integration/tutorial/run/analysis/verify_grammar_module_keep.lua
+++ b/syslog/tests/integration/tutorial/run/analysis/verify_grammar_module_keep.lua
@@ -1,0 +1,40 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require "os"
+require "string"
+local test = require "test_verify_message"
+
+local messages = {
+    {
+        Timestamp = os.time({year = os.date("%Y"), month = 2, day = 14, hour = 19, min = 20, sec = 21}) * 1e9,
+        Logger = "input.grammar_module_keep",
+        Hostname = "ubuntu",
+        Pid = 3453,
+        Payload = 'Feb 14 19:20:21 ubuntu someapp[3453]: foo=bar a=14 baz="hello kitty" cool%story=bro f %^asdf ip=216.160.83.56',
+        Fields = {
+            a = "14",
+            foo = "bar",
+            ["cool%story"] = "bro",
+            baz = "hello kitty",
+            ["%^asdf"] = true,
+            programname = "someapp",
+            f = true,
+            ip = "216.160.83.56"
+        }
+    }
+}
+
+local cnt = 0
+function process_message()
+    cnt = cnt + 1
+    local received = decode_message(read_message("raw"))
+    test.fields_array_to_hash(received)
+    test.verify_msg(messages[cnt], received, cnt)
+    return 0
+end
+
+function timer_event(ns)
+    assert(cnt == #messages, string.format("%d of %d tests ran", cnt, #messages))
+end

--- a/syslog/tests/integration/tutorial/run/input/grammar_module_keep.cfg
+++ b/syslog/tests/integration/tutorial/run/input/grammar_module_keep.cfg
@@ -5,7 +5,7 @@ decoder_module = "decoders.syslog"
 
 decoders_syslog = {
   template = "%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%",
-  payload_keep = true,
+  keep_data = '@message',
 
   sub_decoders = {
     someapp = "lpeg.logfmt",

--- a/syslog/tests/integration/tutorial/run/input/grammar_module_keep.cfg
+++ b/syslog/tests/integration/tutorial/run/input/grammar_module_keep.cfg
@@ -1,0 +1,13 @@
+filename = "file.lua"
+input_filename = "grammar_module.log"
+send_decode_failures = true
+decoder_module = "decoders.syslog"
+
+decoders_syslog = {
+  template = "%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%",
+  payload_keep = true,
+
+  sub_decoders = {
+    someapp = "lpeg.logfmt",
+  },
+}


### PR DESCRIPTION
Hello Trink,

This patch is written to solve my problem, which was that the original Payload dropped off of my messages when using a sub_decoder in the syslog module.

I'm just hacking away, so do tell me if I need to proceed in a different way. I kept an eye on how the nginx module supports this option, and added a small integration test.

