### PR TITLE
Create client in process_message

### DIFF
--- a/socket/CMakeLists.txt.socket
+++ b/socket/CMakeLists.txt.socket
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(socket VERSION 3.0.11 LANGUAGES C)
+project(socket VERSION 3.0.12 LANGUAGES C)
 
 set(CPACK_PACKAGE_NAME luasandbox-${PROJECT_NAME})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lua Socket Modules")

--- a/socket/sandboxes/heka/output/heka_tcp.lua
+++ b/socket/sandboxes/heka/output/heka_tcp.lua
@@ -61,8 +61,7 @@ local function create_client()
     return c, err
 end
 
-local client, err = create_client()
-
+local client, err
 local time_t = 0
 function process_message()
     if not client then

--- a/socket/sandboxes/heka/output/heka_tcp.lua
+++ b/socket/sandboxes/heka/output/heka_tcp.lua
@@ -46,15 +46,19 @@ if ssl_params then
 end
 
 local function create_client()
-    local c, err = socket.connect(address, port)
+    local success
+    local c, err = socket.tcp()
     if c then
-        c:setoption("tcp-nodelay", true)
-        c:setoption("keepalive", true)
         c:settimeout(timeout)
-        if ssl_ctx then
-            c, err = ssl.wrap(c, ssl_ctx)
-            if c then
-                c:dohandshake()
+        success, err = c:connect(address, port)
+        if success then
+            c:setoption("tcp-nodelay", true)
+            c:setoption("keepalive", true)
+            if ssl_ctx then
+                c, err = ssl.wrap(c, ssl_ctx)
+                if c then
+                    c:dohandshake()
+                end
             end
         end
     end


### PR DESCRIPTION
this is to avoid socket.connect blocking the creation of the sandbox.

We had a case were the heka_tcp server was listening but the socket.connect would not complete (and it does not seem to timedout neither), so hindsight seems to be blocked creating this output sandbox and the hindsight.cp checkpoint file was not created.