### PR TITLE
Untrust the stat= key; value can contain garbage

### DIFF
--- a/syslog/CMakeLists.txt
+++ b/syslog/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0)
-project(syslog VERSION 1.0.14 LANGUAGES C)
+project(syslog VERSION 1.0.15 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Syslog parsers and collectors")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${PACKAGE_PREFIX}-lpeg (>= 1.0.9), ${PACKAGE_PREFIX}-socket (>= 3.0)")
 string(REGEX REPLACE "[()]" "" CPACK_RPM_PACKAGE_REQUIRES ${CPACK_DEBIAN_PACKAGE_DEPENDS})

--- a/syslog/modules/lpeg/sendmail.lua
+++ b/syslog/modules/lpeg/sendmail.lua
@@ -21,7 +21,9 @@ setfenv(1, M) -- Remove external access to contain everything in the module
 local sep = l.P", "
 local key = l.C(l.alpha^1)
 local value = l.C((l.P(1) - sep)^1)
-local pair = l.Cg(key * "=" * value) * sep^-1
+local statpair = l.Cg(l.C(l.P'stat') * l.P'=' * l.C(l.P(1)^0))
+local normalpair = l.Cg(key * "=" * value) * sep^-1
+local pair = statpair + normalpair
 
 local sendmailid = l.Cg(l.alnum^-8 * l.digit^6, "sendmailid") * l.P": "
 

--- a/syslog/modules/lpeg/sendmail.lua
+++ b/syslog/modules/lpeg/sendmail.lua
@@ -21,7 +21,7 @@ setfenv(1, M) -- Remove external access to contain everything in the module
 local sep = l.P", "
 local key = l.C(l.alpha^1)
 local value = l.C((l.P(1) - sep)^1)
-local statpair = l.Cg(l.C(l.P'stat') * l.P'=' * l.C(l.P(1)^0))
+local statpair = l.Cg(l.C(l.P"stat") * "=" * l.C(l.P(1)^0))
 local normalpair = l.Cg(key * "=" * value) * sep^-1
 local pair = statpair + normalpair
 

--- a/syslog/tests/sendmail.lua
+++ b/syslog/tests/sendmail.lua
@@ -33,3 +33,15 @@ assert(fields.relay == 'remote.example.com [192.168.1.1]', fields.relay)
 log = 'NOQUEUE: SYSERR(nobody): can not write to queue directory /var/spool/clientmqueue/'
 fields = grammar:match(log)
 assert(fields == nil, 'no match for other errors')
+
+log = 'x6OAO3PO023456: to=<kai@office.example.com>, delay=00:00:00, xdelay=00:00:00, mailer=smtp, pri=235332, relay=webmail.office.example.com. [192.168.1.168], dsn=2.0.0, stat=Sent (<4cb171fbd6e92fed42e1344934c6f130@smtp.example.com> [InternalId=1234567890, Hostname=Exchange.office.example.com] Queued mail for delivery)'
+fields = grammar:match(log)
+assert(fields.sendmailid == 'x6OAO3PO023456', fields.sendmailid)
+assert(fields.to == '<kai@office.example.com>', fields.to)
+assert(fields.delay == '00:00:00', fields.delay)
+assert(fields.xdelay == '00:00:00', fields.xdelay)
+assert(fields.mailer == 'smtp', fields.mailer)
+assert(fields.pri == '235332', fields.pri)
+assert(fields.relay == 'webmail.office.example.com. [192.168.1.168]', fields.relay)
+assert(fields.dsn == '2.0.0', fields.dsn)
+assert(fields.stat == 'Sent (<4cb171fbd6e92fed42e1344934c6f130@smtp.example.com> [InternalId=1234567890, Hostname=Exchange.office.example.com] Queued mail for delivery)', fields.stat)


### PR DESCRIPTION
I ran into a mail server reply with "Hostname=...." stuff which overwrote the Hostname key set by the parent (syslog) decoder.