### PR TITLE
Updated queries and gcp automation

### DIFF
--- a/taskcluster/cloud_functions/mach_try_table_exports/mach_try_table_exports.py
+++ b/taskcluster/cloud_functions/mach_try_table_exports/mach_try_table_exports.py
@@ -1,0 +1,51 @@
+from google.cloud import bigquery
+from google.cloud import storage
+
+
+CONFIG = {
+    'bucket_name': 'mozilla-mach-data',
+    'project': 'moz-fx-data-taskclu-prod-8fbf',
+    'dataset_id': 'taskclusteretl',
+    'tables': {
+        'task_duration_estimates': 'task_duration_history.json',
+        'calculated_machtry_quantiles': 'machtry_quantiles.csv',
+    }
+}
+
+
+def export_all_files(request, payload):
+    for table, blob_name in CONFIG['tables'].items():
+        if blob_name.endswith('.csv'):
+            export_format = bigquery.job.DestinationFormat().CSV
+        else:
+            export_format = bigquery.job.DestinationFormat().NEWLINE_DELIMITED_JSON
+        export_table(table, blob_name, export_format)
+
+
+def export_table(table, blob_name, export_format):
+    storage_client = storage.Client()
+    client = bigquery.Client()
+
+    temporary_blob_name = blob_name + ".temp"
+    destination_uri = "gs://{}/{}".format(CONFIG['bucket_name'], temporary_blob_name)
+    dataset_ref = client.dataset(CONFIG['dataset_id'], project=CONFIG['project'])
+    table_ref = dataset_ref.table(table)
+    job_config = bigquery.job.ExtractJobConfig(
+        destination_format=export_format
+    )
+
+    extract_job = client.extract_table(
+        table_ref,
+        destination_uri,
+        # Location must match that of the source table.
+        location="US",
+        job_config=job_config,
+    )  # API request
+    extract_job.result()  # Waits for job to complete.
+
+    bucket = storage_client.get_bucket(CONFIG['bucket_name'])
+    blob = bucket.blob(temporary_blob_name)
+    bucket.rename_blob(blob, blob_name)
+
+    blob = bucket.blob(blob_name)
+    blob.make_public()

--- a/taskcluster/cloud_functions/mach_try_table_exports/requirements.txt
+++ b/taskcluster/cloud_functions/mach_try_table_exports/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-bigquery==1.21.0
+google-cloud-storage==1.21.0

--- a/taskcluster/sql/derived_kind_costs.sql
+++ b/taskcluster/sql/derived_kind_costs.sql
@@ -1,0 +1,62 @@
+WITH
+  a AS (
+  SELECT
+    date,
+    project,
+    platform,
+    collection,
+    kind,
+    workerType,
+    taskGroupId,
+    owner,
+    COUNT(*) AS tasks,
+    ROUND(SUM(TIMESTAMP_DIFF(resolved, started, millisecond)) / 1000, 2) AS seconds,
+    ROUND(SUM(TIMESTAMP_DIFF(resolved, started, millisecond)) * ifnull((
+        SELECT
+          cost_per_ms
+        FROM
+          taskclusteretl.derived_cost_per_workertype AS tmp
+        WHERE
+          tmp.workerType = dts.workerType
+          AND tmp.date = DATE(EXTRACT(year
+            FROM
+              dts.date), EXTRACT(month
+            FROM
+              dts.date), 1)),
+        (
+        SELECT
+          cost_per_ms
+        FROM
+          taskclusteretl.derived_cost_per_workertype AS tmp
+        WHERE
+          tmp.workerType = dts.workerType
+          AND tmp.date = "1970-01-01")), 2) AS cost
+    -- 1970-01-01 stores the most recent cost we have for each workerType (since the manual data load is 4-6 weeks behind)
+  FROM
+    taskclusteretl.derived_task_summary AS dts
+  WHERE
+    date = DATE_SUB(@run_date, INTERVAL 1 day)
+  GROUP BY
+    date,
+    project,
+    platform,
+    collection,
+    kind,
+    workerType,
+    taskGroupId,
+    owner)
+SELECT
+  a.*,
+  name AS owner_name,
+  manager AS manager_name
+FROM
+  a
+JOIN (
+  SELECT
+    email,
+    name,
+    manager
+  FROM
+    taskclusteretl.mozilla_com)
+ON
+  email = a.owner

--- a/taskcluster/sql/derived_taskgroup_costs.sql
+++ b/taskcluster/sql/derived_taskgroup_costs.sql
@@ -1,0 +1,45 @@
+WITH
+  a AS (
+  SELECT
+    MIN(date) AS date,
+    project,
+    taskGroupId,
+    SUM(tasks) AS tasks,
+    SUM(seconds) AS total_seconds,
+    SUM(cost) AS cost
+  FROM
+    taskclusteretl.derived_kind_costs
+  WHERE
+    date = DATE_SUB(@run_date, INTERVAL 1 day)
+  GROUP BY
+    taskGroupId,
+    project),
+  b AS (
+  SELECT
+    taskGroupId,
+    MIN(started) AS started,
+    MAX(resolved) AS resolved
+  FROM
+    taskclusteretl.derived_task_summary dts
+  GROUP BY
+    taskGroupId)
+SELECT
+  a.*,
+  b.started,
+  b.resolved,
+  TIMESTAMP_DIFF(b.resolved, b.started, millisecond) / 1000 AS wall_clock_seconds
+FROM
+  a
+JOIN
+  b
+ON
+  a.taskGroupId = b.taskGroupId
+GROUP BY
+  taskGroupId,
+  a.date,
+  a.project,
+  a.tasks,
+  a.total_seconds,
+  a.cost,
+  b.started,
+  b.resolved

--- a/taskcluster/sql/derived_taskgroup_costs.sql
+++ b/taskcluster/sql/derived_taskgroup_costs.sql
@@ -10,7 +10,7 @@ WITH
   FROM
     taskclusteretl.derived_kind_costs
   WHERE
-    date = DATE_SUB(@run_date, INTERVAL 1 day)
+    date = DATE_SUB(@run_date, INTERVAL 1  day) 
   GROUP BY
     taskGroupId,
     project),
@@ -27,13 +27,35 @@ SELECT
   a.*,
   b.started,
   b.resolved,
-  TIMESTAMP_DIFF(b.resolved, b.started, millisecond) / 1000 AS wall_clock_seconds
+  TIMESTAMP_DIFF(b.resolved, b.started, millisecond) / 1000 AS wall_clock_seconds,
+  release_promotion_flavor,
+  build_number,
+  release_version,
+  action,
+  tasks_for
 FROM
   a
 JOIN
   b
 ON
   a.taskGroupId = b.taskGroupId
+JOIN (
+  SELECT
+    taskId,
+    JSON_EXTRACT_SCALAR(extra,
+      "$.action.context.input.release_promotion_flavor") AS release_promotion_flavor,
+    JSON_EXTRACT_SCALAR(extra,
+      "$.action.context.input.build_number") AS build_number,
+    JSON_EXTRACT_SCALAR(extra,
+      "$.action.context.input.version") AS release_version,
+    JSON_EXTRACT_SCALAR(extra,
+      "$.action.name") AS action,
+    JSON_EXTRACT_SCALAR(extra,
+      "$.tasks_for") AS tasks_for
+  FROM
+    taskclusteretl.task_definition )
+ON
+  taskId = a.taskGroupId
 GROUP BY
   taskGroupId,
   a.date,
@@ -42,4 +64,9 @@ GROUP BY
   a.total_seconds,
   a.cost,
   b.started,
-  b.resolved
+  b.resolved,
+  release_promotion_flavor,
+  build_number,
+  release_version,
+  action,
+  tasks_for

--- a/taskcluster/sql/machtry_quantiles.sql
+++ b/taskcluster/sql/machtry_quantiles.sql
@@ -1,0 +1,18 @@
+WITH
+  a AS (
+  SELECT
+    APPROX_QUANTILES(total_seconds, 100 IGNORE NULLS) AS quants
+  FROM
+    `moz-fx-data-taskclu-prod-8fbf.taskclusteretl.derived_taskgroup_costs`
+  WHERE
+    project = 'try'
+    AND cost IS NOT NULL
+    AND date > DATE_SUB(@run_date, INTERVAL 60 day) )
+SELECT
+  quant
+FROM
+  a
+CROSS JOIN
+  UNNEST(a.quants) AS quant
+ORDER BY
+  quant ASC


### PR DESCRIPTION
Updated some of the derivation queries with the needed values. I'll go through and have a clear-up soon, to avoid duplication.

I've added some automation to export the tables required for `mach try fuzzy --show-estimates` using cloud scheduler and a cloud function. Storing those here.