### PR TITLE
Issue 475 - Add a migration URL for automatic switch over

### DIFF
--- a/taskcluster/tests/integration/taskcluster/run/analysis/verify_error.lua
+++ b/taskcluster/tests/integration/taskcluster/run/analysis/verify_error.lua
@@ -8,11 +8,11 @@ require "table"
 local captures = {""}
 local results = {
     {type = 'error.log.schema', message = 'unclosed block'},
-    {type = 'error.decode', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:772: Expected value but found T_OBJ_END at character 1'},
-    {type = 'error.perfherder.parse', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:192: Expected comma or object end but found T_COLON at character 21'},
+    {type = 'error.decode', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:799: Expected value but found T_OBJ_END at character 1'},
+    {type = 'error.perfherder.parse', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:194: Expected comma or object end but found T_COLON at character 21'},
     {type = 'error.perfherder.validation', message = 'SchemaURI: #/properties/suites Keyword: type DocumentURI: #/suites'},
-    {type = 'error.decode', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:806: missing_task.task.json: No such file or directory'},
-    {type = 'error.decode', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:964: missing_log.log: No such file or directory'}
+    {type = 'error.decode', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:824: missing_task.task.json: No such file or directory'},
+    {type = 'error.decode', message = '...io_modules/decoders/taskcluster/live_backing_log.lua:987: missing_log.log: No such file or directory'}
 }
 
 local cnt = 0


### PR DESCRIPTION
After the new cluster deployment the old URL should fail to fetch
current task data from queue.taskcluster.net and the new migration URL
will become active after the first successful retrieval.