### PR TITLE
Issue #485 - Add a test for a checkpoint beyond the EOF

### DIFF
--- a/lfs/CMakeLists.txt.lfs
+++ b/lfs/CMakeLists.txt.lfs
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(lfs VERSION 1.6.6 LANGUAGES C)
+project(lfs VERSION 1.6.7 LANGUAGES C)
 
 set(CPACK_PACKAGE_NAME luasandbox-${PROJECT_NAME})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lua FileSystem Module")

--- a/lfs/sandboxes/heka/input/tail.lua
+++ b/lfs/sandboxes/heka/input/tail.lua
@@ -143,8 +143,9 @@ local function open_file(checkpoint)
     if not fh then return nil, 0 end
 
     if checkpoint ~= 0 then
-        if not fh:seek("set", checkpoint) then
-            print("invalid checkpoint, starting from the beginning")
+        local seek = fh:seek("end")
+        if checkpoint > seek or not fh:seek("set", checkpoint) then
+            print(string.format("invalid checkpoint: %d end: %d, starting from the beginning", checkpoint, seek))
             checkpoint = 0
             inject_message(nil, checkpoint)
         end


### PR DESCRIPTION
```
1574110765512931326 [info] input.tail starting
1574110765513067259 [debug] input.tail invalid checkpoint: 48641602 end: 79, starting from the beginning
1574110765513160998 [info] analysis_plugins starting thread: 0
```

