### PR TITLE
Fix cmake copy_directory issue on Debian Buster

### DIFF
--- a/cmake/sandbox_ep_test.cmake
+++ b/cmake/sandbox_ep_test.cmake
@@ -11,10 +11,11 @@ else()
 endif()
 include(CTest)
 
-add_custom_target(${PROJECT_NAME}_copy_tests ALL
-COMMAND ${CMAKE_COMMAND} -E copy_directory
-${CMAKE_CURRENT_SOURCE_DIR}/tests
-${CMAKE_CURRENT_BINARY_DIR})
+if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_custom_target(${PROJECT_NAME}_copy_tests ALL COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_SOURCE_DIR}/tests
+            ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 
 if(COPY_TEST_MAXMINDDB)
     add_custom_target(${MODULE_NAME}_copy_test_maxminddb_city ALL COMMAND ${CMAKE_COMMAND} -E copy

--- a/cmake/sandbox_module.cmake
+++ b/cmake/sandbox_module.cmake
@@ -52,9 +52,11 @@ if(IS_DIRECTORY ${SCHEMA_DIR})
     install(DIRECTORY ${SCHEMA_DIR}/ DESTINATION ${INSTALL_SCHEMA_PATH} ${DPERMISSION})
 endif()
 
-add_custom_target(${MODULE_NAME}_copy_tests ALL COMMAND ${CMAKE_COMMAND} -E copy_directory
-${CMAKE_CURRENT_SOURCE_DIR}/tests
-${CMAKE_CURRENT_BINARY_DIR})
+if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    add_custom_target(${MODULE_NAME}_copy_tests ALL COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests
+        ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 
 if(COPY_TEST_MAXMINDDB)
     add_custom_target(${MODULE_NAME}_copy_test_maxminddb ALL COMMAND ${CMAKE_COMMAND} -E copy


### PR DESCRIPTION
if the {CMAKE_CURRENT_SOURCE_DIR}/tests directory does not exist, cmake
raise an error on Debian Buster.