### PR TITLE
[taskclusteretl] Add default management chain for unknown identities

### DIFF
--- a/taskcluster/sql/derived_kind_costs.sql
+++ b/taskcluster/sql/derived_kind_costs.sql
@@ -86,7 +86,7 @@ SELECT
   cost,
   ifnull(name,
     a.owner) AS owner_name,
-  manager AS manager_name,
+  IFNULL(manager, ["Collaborator", "Mitchell Baker"]) AS manager_name,
   workerGroup
 FROM
   a

--- a/taskcluster/sql/derived_test_suite_costs.sql
+++ b/taskcluster/sql/derived_test_suite_costs.sql
@@ -86,7 +86,7 @@ SELECT
   cost,
   ifnull(name,
     a.owner) AS owner_name,
-  manager AS manager_name,
+  IFNULL(manager, ["Collaborator", "Mitchell Baker"]) AS manager_name,
   workerGroup
 FROM
   a

--- a/taskcluster/sql/derived_workertype_costs.sql
+++ b/taskcluster/sql/derived_workertype_costs.sql
@@ -100,7 +100,7 @@ WITH
     cost.* EXCEPT(description),
     ifnull(name,
       cost.owner) AS owner_name,
-    manager AS manager_name,
+    IFNULL(manager, ["Collaborator", "Mitchell Baker"]) AS manager_name,
     cost.description
   FROM
     cost

--- a/taskcluster/sql/derived_workertype_costs_community.sql
+++ b/taskcluster/sql/derived_workertype_costs_community.sql
@@ -99,7 +99,7 @@ WITH
     cost.* EXCEPT(description),
     ifnull(name,
       cost.owner) AS owner_name,
-    manager AS manager_name,
+    IFNULL(manager, ["Collaborator", "Mitchell Baker"]) AS manager_name,
     cost.description
   FROM
     cost

--- a/taskcluster/sql/derived_workertype_costs_stage.sql
+++ b/taskcluster/sql/derived_workertype_costs_stage.sql
@@ -99,7 +99,7 @@ WITH
     cost.* EXCEPT(description),
     ifnull(name,
       cost.owner) AS owner_name,
-    manager AS manager_name,
+    IFNULL(manager, ["Collaborator", "Mitchell Baker"]) AS manager_name,
     cost.description
   FROM
     cost


### PR DESCRIPTION
When rolling up the costs based on the org chart, a lot of costs are orphaned:

1. Collaborators
2. Github CI activity where a person's Github username isn't on people.m.o
3. Other activity from people in the org chart but who are using other identities for commits

Since the bulk of these is likely collaborators, this change adds a default in the situation where the `join` with `person_mozilla_com` produces no management chain. Adding the CEO allows the total in the reports to line up with the data that doesn't sort things this way, and reinforces the idea that they're ultimately accountable for the cost. The fake manager "Collaborator" acts as an intermediary to avoid polluting the CEO's direct reports and lets us view these other identities as a group.

(I've not yet deployed these changes)