### PR TITLE
Elastic tls

### DIFF
--- a/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
+++ b/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
@@ -77,7 +77,7 @@ if ssl_params then
 end
 
 local function connection_factory()
-    local t = {c = try(socket.tcp())}
+    local t = {c = socket.try(socket.tcp())}
 
     function idx (tbl, key)
         return function (prxy, ...)
@@ -88,15 +88,15 @@ local function connection_factory()
 
     function t:connect(host, port)
         -- print ("proxy connect ", host, port)
-        try(self.c:connect(host, port))
+        socket.try(self.c:connect(host, port))
         self.c:setoption("tcp-nodelay", true)
         self.c:setoption("keepalive", true)
         self.c:settimeout(timeout)
         if ssl_params then
-            self.c = try(ssl.wrap(self.c, ssl_params))
+            self.c = socket.try(ssl.wrap(self.c, ssl_params))
             self.c:sni(host)
             -- print("TLS wrapped!") -- debug
-            try(self.c:dohandshake())
+            socket.try(self.c:dohandshake())
             -- print("TLS handshaked!") -- debug
         end
         return 1

--- a/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
+++ b/elasticsearch/sandboxes/heka/output/elasticsearch_bulk_api.lua
@@ -53,7 +53,7 @@ local timeout       = read_config("timeout") or 10
 local discard       = read_config("discard_on_error")
 local abort         = read_config("abort_on_error")
 local max_retry     = read_config("max_retry") or 0
-local ssl_params    = read_config("ssl_params") or false
+local ssl_params    = read_config("ssl_params")
 assert(not (abort and discard), "abort_on_error and discard_on_error are mutually exclusive")
 
 local encoder_module = read_config("encoder_module") or "encoders.elasticsearch.payload"
@@ -87,7 +87,6 @@ local function connection_factory()
     end
 
     function t:connect(host, port)
-        -- print ("proxy connect ", host, port)
         socket.try(self.c:connect(host, port))
         self.c:setoption("tcp-nodelay", true)
         self.c:setoption("keepalive", true)
@@ -95,9 +94,7 @@ local function connection_factory()
         if ssl_params then
             self.c = socket.try(ssl.wrap(self.c, ssl_params))
             self.c:sni(host)
-            -- print("TLS wrapped!") -- debug
             socket.try(self.c:dohandshake())
-            -- print("TLS handshaked!") -- debug
         end
         return 1
     end


### PR DESCRIPTION
I have pulled in the original #201, but I don't think I can push to that branch. I have based my work a bit on it.

I wonder if the module cannot go back to use the plain 'http.request': has support for passing it a connection factory: http://w3.impa.br/~diego/software/luasocket/http.html . Let me know what you think, as it is slightly more work.

I haven't built a test! Perhaps you have a suggestion on if, and how to test this?