### PR TITLE
Remove default type as Elastic 7 deprecates document types

### DIFF
--- a/elasticsearch/CMakeLists.txt
+++ b/elasticsearch/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0)
-project(elasticsearch VERSION 1.0.8 LANGUAGES C)
+project(elasticsearch VERSION 1.0.9 LANGUAGES C)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Elasticsearch encoders and outputs")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${PACKAGE_PREFIX}-heka (>= 1.0), ${PACKAGE_PREFIX}-rjson (>= 1.0), ${PACKAGE_PREFIX}-cjson (>= 2.1), ${PACKAGE_PREFIX}-socket (>= 3.0)")
 string(REGEX REPLACE "[()]" "" CPACK_RPM_PACKAGE_REQUIRES ${CPACK_DEBIAN_PACKAGE_DEPENDS})

--- a/elasticsearch/io_modules/encoders/elasticsearch/common.lua
+++ b/elasticsearch/io_modules/encoders/elasticsearch/common.lua
@@ -19,7 +19,7 @@ encoders_elasticsearch_common = {
 
     -- String to use as the `_type` key's value in the generated JSON.
     -- Supports field interpolation as described below.
-    type_name = "message" -- optional, default shown
+    type_name = "_doc" -- optional, default shown
 
     -- String to use as the `_id` key's value in the generated JSON.
     -- Supports field interpolation as described below.
@@ -126,7 +126,7 @@ function load_encoder_cfg()
     end
 
     if cfg.type_name == nil then
-        cfg.type_name = "message"
+        cfg.type_name = "_doc"
     else
         assert(type(cfg.type_name) == "string", "type_name must be nil or a string")
     end

--- a/elasticsearch/io_modules/encoders/elasticsearch/common.lua
+++ b/elasticsearch/io_modules/encoders/elasticsearch/common.lua
@@ -13,13 +13,17 @@ encoders_elasticsearch_common = {
     -- than the system time.
     es_index_from_timestamp = false -- optional, default shown
 
+    -- Elastic 7 and newer are moving to type-less documents (use `type_name = nil` or `_doc`)
+    -- https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
+    es_version = 5 -- optional, default shown
+
     -- String to use as the `_index` key's value in the  generated JSON.
     -- Supports field interpolation as described below.
     index = "heka-%{%Y.%m.%d}" -- optional, default shown
 
     -- String to use as the `_type` key's value in the generated JSON.
     -- Supports field interpolation as described below.
-    type_name = "_doc" -- optional, default shown
+    type_name = nil -- optional, default shown
 
     -- String to use as the `_id` key's value in the generated JSON.
     -- Supports field interpolation as described below.
@@ -126,7 +130,11 @@ function load_encoder_cfg()
     end
 
     if cfg.type_name == nil then
-        cfg.type_name = "_doc"
+      if cfg.es_version < 7 then
+        cfg.type_name = "message"
+      else
+        assert(cfg.type_name == "_doc", "type_name must be nil or _doc, types are deprecated since Elasic 7.0")
+      end
     else
         assert(type(cfg.type_name) == "string", "type_name must be nil or a string")
     end


### PR DESCRIPTION
In order to be compatible with recent Elastic versions document type information should not be defined or `_doc` type could be used.

`_doc` is a dummy document type that will work as well with older Elastic versions

See: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html