### PR TITLE
taskclusteretl: exclude static providers in worker pool configuration

### DIFF
--- a/taskcluster/sandboxes/heka/input/taskcluster_capacity.lua
+++ b/taskcluster/sandboxes/heka/input/taskcluster_capacity.lua
@@ -73,16 +73,19 @@ local function process_config(y, time_t)
     local dstr = os.date("%Y-%m-%d", time_t)
     local entries = {}
     for i,v in ipairs(y.pools) do
-        local pid, wt = string.match(v.pool_id, "([^/]+)/(.+)")
-        for m,n in ipairs(v.config.instance_types) do
-            local cap = n.capacityPerInstance or 1
-            if cap > 1 then
-                if pid == "{pool-group}" then
-                    for o,p in ipairs(v.variants) do
-                        entries[#entries + 1] = {date = dstr, provisionerId = p["pool-group"], workerType = wt, providerId = v.provider_id, capacity = cap, instanceType = n.instanceType or n.machine_type}
+        -- 'static' providers do not contain instance_types configuration
+        if v.provider_id ~= "static" then
+            local pid, wt = string.match(v.pool_id, "([^/]+)/(.+)")
+            for m,n in ipairs(v.config.instance_types) do
+                local cap = n.capacityPerInstance or 1
+                if cap > 1 then
+                    if pid == "{pool-group}" then
+                        for o,p in ipairs(v.variants) do
+                            entries[#entries + 1] = {date = dstr, provisionerId = p["pool-group"], workerType = wt, providerId = v.provider_id, capacity = cap, instanceType = n.instanceType or n.machine_type}
+                        end
+                    else
+                        entries[#entries + 1] = {date = dstr, provisionerId = pid, workerType = wt, providerId = v.provider_id, capacity = cap, instanceType = n.instanceType or n.machine_type}
                     end
-                else
-                    entries[#entries + 1] = {date = dstr, provisionerId = pid, workerType = wt, providerId = v.provider_id, capacity = cap, instanceType = n.instanceType or n.machine_type}
                 end
             end
         end


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1681843. It is my understanding that the static provider pool configuration are statically created outside of taskcluster control and these can be ignored as part of the import. We do manage these static deployments of resources in the ETL directly. 

Tested the change on taskclusteretl-dev environment. 

r?