### PR TITLE
Add circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,81 @@
+# These environment variables must be set in CircleCI UI
+#
+# DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
+# DOCKER_USER
+# DOCKER_PASS
+#
+
+version: 2.1
+jobs:
+  build_test:
+    docker:
+      - image: mozilla/cidockerbases:docker-latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    working_directory: /
+    steps:
+      - checkout:
+          path: /lua_sandbox_extensions
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: 19.03.13
+
+      - run:
+          working_directory: /lua_sandbox_extensions
+          command: |
+            docker build -t local/lua_sandbox_extensions .
+
+      - run:
+          command: |
+            docker run local/lua_sandbox_extensions \
+            bash -c 'cd /root/lua_sandbox_extensions/release && ctest -V -C integration'
+
+      - run: docker save -o /tmp/docker_image_build.tar local/lua_sandbox_extensions
+
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - docker_image_build.tar
+  deploy:
+    docker:
+      - image: mozilla/cidockerbases:docker-latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    working_directory: /
+    steps:
+      - checkout:
+          path: /lua_sandbox_extensions
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: 19.03.13
+
+      - attach_workspace:
+          at: /tmp/workspace
+
+      - run: docker load -i /tmp/workspace/docker_image_build.tar
+
+      - run:
+          working_directory: /lua_sandbox_extensions
+          command: |
+            ./docker_push.sh $CIRCLE_BRANCH
+
+workflows:
+  version: 2.1
+  build_test_deploy:
+    jobs:
+      - build_test:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build_test
+          filters:
+            branches:
+              only:
+                - dev
+                - test
+                - master

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -11,6 +11,6 @@ else
     exit 1
 fi
 
-docker tag mozilla/lua_sandbox_extensions $tag
+docker tag local/lua_sandbox_extensions $tag
 docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 docker push $tag


### PR DESCRIPTION
TravisCI org is no longer working reliably so I've switched to using CircleCI. Tested build, test and deploy flow using the `test` branch [1]. I have *not* ported over the artifact publishing step defined in the travis-ci configuration, which I believe publishes RPMs to S3 [2]. I don't believe we need this anymore but let me know if we still want to maintain this.

[1] https://app.circleci.com/pipelines/github/mozilla-services/lua_sandbox_extensions/11/workflows/87abaf65-2b28-48c9-9572-e7ec745e1066
[2]  https://github.com/mozilla-services/lua_sandbox_extensions/blob/master/.travis.yml#L18-L23